### PR TITLE
ci: fix workflow group exclusion

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        tools: composer
         extensions: fileinfo
         coverage: none
 
@@ -34,4 +33,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      run: vendor/bin/pest --exclude-groups=performance --colors=always
+      run: vendor/bin/pest --exclude-group=performance --colors=always


### PR DESCRIPTION
The flag for excluding groups should be singular. 👍🏻 Also, the `composer` tool is unnecessary as it's installed by default.