### PR TITLE
Use static return type over self

### DIFF
--- a/src/Concerns/ConditionalRules.php
+++ b/src/Concerns/ConditionalRules.php
@@ -47,13 +47,12 @@ trait ConditionalRules
      * @param bool|(\Closure($this): bool) $value
      * @param string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array<string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule> $rule
      * @param string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array<string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule>|null $default
-     * @return $this
      */
     public function when(
         bool|Closure $value,
         string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array $rule,
         string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array|null $default = null
-    ): self {
+    ): static {
         $value = $value instanceof Closure ? $value($this) : $value;
 
         return $this->rule($value ? $rule : $default);
@@ -66,13 +65,12 @@ trait ConditionalRules
      * @param bool|(\Closure($this): bool) $value
      * @param string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array<string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule> $rule
      * @param string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array<string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule>|null $default
-     * @return $this
      */
     public function unless(
         bool|Closure $value,
         string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array $rule,
         string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array|null $default = null
-    ): self {
+    ): static {
         $value = $value instanceof Closure ? $value($this) : $value;
 
         return $this->rule((! $value) ? $rule : $default);

--- a/src/Concerns/CoreRules.php
+++ b/src/Concerns/CoreRules.php
@@ -31,189 +31,168 @@ trait CoreRules
 {
     /**
      * @link https://laravel.com/docs/master/validation#rule-accepted
-     * @return $this
      */
-    public function accepted(): self
+    public function accepted(): static
     {
         return $this->rule('accepted');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-accepted-if
-     * @return $this
      */
-    public function acceptedIf(string ...$fieldsAndValues): self
+    public function acceptedIf(string ...$fieldsAndValues): static
     {
         return $this->rule('accepted_if'.self::arguments($fieldsAndValues));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-active-url
-     * @return $this
      */
-    public function activeUrl(): self
+    public function activeUrl(): static
     {
         return $this->rule('active_url');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-after
-     * @return $this
      */
-    public function after(string|DateTimeInterface $date): self
+    public function after(string|DateTimeInterface $date): static
     {
         return $this->rule('after'.self::arguments($date));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-after-or-equal
-     * @return $this
      */
-    public function afterOrEqual(string|DateTimeInterface $date): self
+    public function afterOrEqual(string|DateTimeInterface $date): static
     {
         return $this->rule('after_or_equal'.self::arguments($date));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-alpha
-     * @return $this
      */
-    public function alpha(string $range = null): self
+    public function alpha(string $range = null): static
     {
         return $this->rule('alpha'.self::arguments($range));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-alpha-dash
-     * @return $this
      */
-    public function alphaDash(string $range = null): self
+    public function alphaDash(string $range = null): static
     {
         return $this->rule('alpha_dash'.self::arguments($range));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-alpha-numeric
-     * @return $this
      */
-    public function alphaNumeric(string $range = null): self
+    public function alphaNumeric(string $range = null): static
     {
         return $this->rule('alpha_numeric'.self::arguments($range));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-array
-     * @return $this
      */
-    public function array(string ...$keys): self
+    public function array(string ...$keys): static
     {
         return $this->rule('array'.self::arguments($keys));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-ascii
-     * @return $this
      */
-    public function ascii(): self
+    public function ascii(): static
     {
         return $this->rule('ascii');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-bail
-     * @return $this
      */
-    public function bail(): self
+    public function bail(): static
     {
         return $this->rule('bail');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-before
-     * @return $this
      */
-    public function before(string|DateTimeInterface $date): self
+    public function before(string|DateTimeInterface $date): static
     {
         return $this->rule('before'.self::arguments($date));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-before-or-equal
-     * @return $this
      */
-    public function beforeOrEqual(string|DateTimeInterface $date): self
+    public function beforeOrEqual(string|DateTimeInterface $date): static
     {
         return $this->rule('before_or_equal'.self::arguments($date));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-between
-     * @return $this
      */
-    public function between(int $min, int $max): self
+    public function between(int $min, int $max): static
     {
         return $this->rule('between:'.$min.','.$max);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-boolean
-     * @return $this
      */
-    public function boolean(): self
+    public function boolean(): static
     {
         return $this->rule('boolean');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-confirmed
-     * @return $this
      */
-    public function confirmed(): self
+    public function confirmed(): static
     {
         return $this->rule('confirmed');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-current-password
-     * @return $this
      */
-    public function currentPassword(string $guard = null): self
+    public function currentPassword(string $guard = null): static
     {
         return $this->rule('current_password'.self::arguments($guard));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-date
-     * @return $this
      */
-    public function date(): self
+    public function date(): static
     {
         return $this->rule('date');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-date-equals
-     * @return $this
      */
-    public function dateEquals(string|DateTimeInterface $date): self
+    public function dateEquals(string|DateTimeInterface $date): static
     {
         return $this->rule('date_equals'.self::arguments($date));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-date-format
-     * @return $this
      */
-    public function dateFormat(string ...$format): self
+    public function dateFormat(string ...$format): static
     {
         return $this->rule('date_format'.self::arguments($format));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-decimal
-     * @return $this
      */
-    public function decimal(int $min, int $max = null): self
+    public function decimal(int $min, int $max = null): static
     {
         $max ??= $min;
 
@@ -222,52 +201,46 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-declined
-     * @return $this
      */
-    public function declined(): self
+    public function declined(): static
     {
         return $this->rule('declined');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-declined-if
-     * @return $this
      */
-    public function declinedIf(string ...$fieldsAndValues): self
+    public function declinedIf(string ...$fieldsAndValues): static
     {
         return $this->rule('declined_if'.self::arguments($fieldsAndValues));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-different
-     * @return $this
      */
-    public function different(string $field): self
+    public function different(string $field): static
     {
         return $this->rule('different:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-digits
-     * @return $this
      */
-    public function digits(int $value): self
+    public function digits(int $value): static
     {
         return $this->rule('digits:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-digits-between
-     * @return $this
      */
-    public function digitsBetween(int $min, int $max): self
+    public function digitsBetween(int $min, int $max): static
     {
         return $this->rule('digits_between:'.$min.','.$max);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-dimensions
-     * @return $this
      */
     public function dimensions(
         string|Dimensions $dimensions = null,
@@ -278,7 +251,7 @@ trait CoreRules
         int $maxWidth = null,
         int $maxHeight = null,
         int $ratio = null,
-    ): self {
+    ): static {
         if ($dimensions === null) {
             $dimensions = RuleClass::dimensions();
 
@@ -316,72 +289,64 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-distinct
-     * @return $this
      */
-    public function distinct(string $mode = null): self
+    public function distinct(string $mode = null): static
     {
         return $this->rule('distinct'.self::arguments($mode));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-doesnt-start-with
-     * @return $this
      */
-    public function doesntStartWith(string ...$prefixes): self
+    public function doesntStartWith(string ...$prefixes): static
     {
         return $this->rule('doesnt_start_with'.self::arguments($prefixes));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-doesnt-end-with
-     * @return $this
      */
-    public function doesntEndWith(string ...$prefixes): self
+    public function doesntEndWith(string ...$prefixes): static
     {
         return $this->rule('doesnt_end_with'.self::arguments($prefixes));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-email
-     * @return $this
      */
-    public function email(string ...$flags): self
+    public function email(string ...$flags): static
     {
         return $this->rule('email'.self::arguments($flags));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-ends-with
-     * @return $this
      */
-    public function endsWith(string ...$prefixes): self
+    public function endsWith(string ...$prefixes): static
     {
         return $this->rule('ends_with'.self::arguments($prefixes));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-enum
-     * @return $this
      */
-    public function enum(string|Enum $enum): self
+    public function enum(string|Enum $enum): static
     {
         return $this->rule($enum instanceof Enum ? $enum : RuleClass::enum($enum));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exclude
-     * @return $this
      */
-    public function exclude(): self
+    public function exclude(): static
     {
         return $this->rule('exclude');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exclude-if
-     * @return $this
      */
-    public function excludeIf(callable|bool|ExcludeIf $condition): self
+    public function excludeIf(callable|bool|ExcludeIf $condition): static
     {
         $excludeIf = $condition instanceof ExcludeIf ? $condition : RuleClass::excludeIf($condition);
 
@@ -390,36 +355,32 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exclude-unless
-     * @return $this
      */
-    public function excludeUnless(string ...$fieldsAndValues): self
+    public function excludeUnless(string ...$fieldsAndValues): static
     {
         return $this->rule('exclude_unless'.self::arguments($fieldsAndValues));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exclude-with
-     * @return $this
      */
-    public function excludeWith(string $field): self
+    public function excludeWith(string $field): static
     {
         return $this->rule('exclude_with:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exclude-without
-     * @return $this
      */
-    public function excludeWithout(string $field): self
+    public function excludeWithout(string $field): static
     {
         return $this->rule('exclude_without:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-exists
-     * @return $this
      */
-    public function exists(string $table, string $column = null): self
+    public function exists(string $table, string $column = null): static
     {
         return $this->rule((string) RuleClass::exists($table, $column ?? 'NULL'));
     }
@@ -428,7 +389,6 @@ trait CoreRules
      * @param array<string> $allowedMimetypes
      * @param string|array<mixed> $customRules
      * @link https://laravel.com/docs/master/validation#rule-file
-     * @return $this
      */
     public function file(
         ?File $file = null,
@@ -436,7 +396,7 @@ trait CoreRules
         int $minKilobytes = null,
         int $maxKilobytes = null,
         string|array $customRules = [],
-    ): self {
+    ): static {
         if ($file === null) {
             $file = RuleClass::file();
 
@@ -463,279 +423,248 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-filled
-     * @return $this
      */
-    public function filled(): self
+    public function filled(): static
     {
         return $this->rule('filled');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-greater-than
-     * @return $this
      */
-    public function gt(string $field): self
+    public function gt(string $field): static
     {
         return $this->rule('gt:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-greater-than-or-equal
-     * @return $this
      */
-    public function gte(string $field): self
+    public function gte(string $field): static
     {
         return $this->rule('gte:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-image
-     * @return $this
      */
-    public function image(ImageFile $image = null): self
+    public function image(ImageFile $image = null): static
     {
         return $this->rule($image ?? 'image');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-in
-     * @return $this
      */
-    public function in(string ...$values): self
+    public function in(string ...$values): static
     {
         return $this->rule('in'.self::arguments($values));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-in-array
-     * @return $this
      */
-    public function inArray(string $field): self
+    public function inArray(string $field): static
     {
         return $this->rule('in_array:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-integer
-     * @return $this
      */
-    public function integer(): self
+    public function integer(): static
     {
         return $this->rule('integer');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-ip
-     * @return $this
      */
-    public function ip(): self
+    public function ip(): static
     {
         return $this->rule('ip');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#ipv4
-     * @return $this
      */
-    public function ipv4(): self
+    public function ipv4(): static
     {
         return $this->rule('ipv4');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#ipv6
-     * @return $this
      */
-    public function ipv6(): self
+    public function ipv6(): static
     {
         return $this->rule('ipv6');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-json
-     * @return $this
      */
-    public function json(): self
+    public function json(): static
     {
         return $this->rule('json');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-less-than
-     * @return $this
      */
-    public function lt(string $field): self
+    public function lt(string $field): static
     {
         return $this->rule('lt:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-less-than-or-equal
-     * @return $this
      */
-    public function lte(string $field): self
+    public function lte(string $field): static
     {
         return $this->rule('lte:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-lowercase
-     * @return $this
      */
-    public function lowercase(): self
+    public function lowercase(): static
     {
         return $this->rule('lowercase');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-mac-address
-     * @return $this
      */
-    public function macAddress(): self
+    public function macAddress(): static
     {
         return $this->rule('mac_address');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-max
-     * @return $this
      */
-    public function max(int $value): self
+    public function max(int $value): static
     {
         return $this->rule('max:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-max-digits
-     * @return $this
      */
-    public function maxDigits(int $digits): self
+    public function maxDigits(int $digits): static
     {
         return $this->rule('max_digits:'.$digits);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-mime-types
-     * @return $this
      */
-    public function mimeTypes(string ...$types): self
+    public function mimeTypes(string ...$types): static
     {
         return $this->rule('mimetypes'.self::arguments($types));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-mime-type-by-file-extension
-     * @return $this
      */
-    public function mimes(string ...$extensions): self
+    public function mimes(string ...$extensions): static
     {
         return $this->rule('mimes'.self::arguments($extensions));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-min
-     * @return $this
      */
-    public function min(int $value): self
+    public function min(int $value): static
     {
         return $this->rule('min:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-min-digits
-     * @return $this
      */
-    public function minDigits(int $value): self
+    public function minDigits(int $value): static
     {
         return $this->rule('min_digits:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-missing
-     * @return $this
      */
-    public function missing(): self
+    public function missing(): static
     {
         return $this->rule('missing');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-missing-if
-     * @return $this
      */
-    public function missingIf(string ...$fieldsAndValues): self
+    public function missingIf(string ...$fieldsAndValues): static
     {
         return $this->rule('missing_if'.self::arguments($fieldsAndValues));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-missing-unless
-     * @return $this
      */
-    public function missingUnless(string ...$fieldsAndValues): self
+    public function missingUnless(string ...$fieldsAndValues): static
     {
         return $this->rule('missing_unless'.self::arguments($fieldsAndValues));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-missing-with
-     * @return $this
      */
-    public function missingWith(string ...$fields): self
+    public function missingWith(string ...$fields): static
     {
         return $this->rule('missing_with'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-missing-with-all
-     * @return $this
      */
-    public function missingWithAll(string ...$fields): self
+    public function missingWithAll(string ...$fields): static
     {
         return $this->rule('missing_with_all'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-multiple-of
-     * @return $this
      */
-    public function multipleOf(int $value): self
+    public function multipleOf(int $value): static
     {
         return $this->rule('multiple_of:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-not-in
-     * @return $this
      */
-    public function notIn(string ...$values): self
+    public function notIn(string ...$values): static
     {
         return $this->rule('not_in'.self::arguments($values));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-not-regex
-     * @return $this
      */
-    public function notRegex(string $regex): self
+    public function notRegex(string $regex): static
     {
         return $this->rule('not_regex:'.$regex);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-nullable
-     * @return $this
      */
-    public function nullable(): self
+    public function nullable(): static
     {
         return $this->rule('nullable');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-numeric
-     * @return $this
      */
-    public function numeric(): self
+    public function numeric(): static
     {
         return $this->rule('numeric');
     }
@@ -743,7 +672,6 @@ trait CoreRules
     /**
      * @link https://laravel.com/docs/master/validation#rule-password
      * @param string|array<mixed> $rules
-     * @return $this
      */
     public function password(
         Password $password = null,
@@ -754,7 +682,7 @@ trait CoreRules
         int|bool $uncompromised = null,
         int $min = null,
         string|array $rules = [],
-    ): self {
+    ): static {
         if ($password === null) {
             $password = Password::default();
 
@@ -793,30 +721,27 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-present
-     * @return $this
      */
-    public function present(): self
+    public function present(): static
     {
         return $this->rule('present');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-prohibited
-     * @return $this
      */
-    public function prohibited(): self
+    public function prohibited(): static
     {
         return $this->rule('prohibited');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-prohibited-if
-     * @return $this
      */
     public function prohibitedIf(
         string|bool|ProhibitedIf $condition = null,
         string ...$fieldsAndValues
-    ): self {
+    ): static {
         if (is_bool($condition)) {
             $condition = new ProhibitedIf($condition);
         }
@@ -834,12 +759,11 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-prohibited-unless
-     * @return $this
      */
     public function prohibitedUnless(
         string|bool $condition = null,
         string ...$fieldsAndValues
-    ): self {
+    ): static {
         if (is_bool($condition)) {
             return $this->prohibitedIf(! $condition);
         }
@@ -853,39 +777,35 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-prohibits
-     * @return $this
      */
-    public function prohibits(string ...$fields): self
+    public function prohibits(string ...$fields): static
     {
         return $this->rule('prohibits'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-regular-expression
-     * @return $this
      */
-    public function regex(string $pattern): self
+    public function regex(string $pattern): static
     {
         return $this->rule('regex:'.$pattern);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required
-     * @return $this
      */
-    public function required(): self
+    public function required(): static
     {
         return $this->rule('required');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-if
-     * @return $this
      */
     public function requiredIf(
         string|bool|RequiredIf|Closure $condition = null,
         string ...$fieldsAndValues
-    ): self {
+    ): static {
         if (is_bool($condition) || $condition instanceof Closure) {
             $condition = new RequiredIf($condition);
         }
@@ -903,12 +823,11 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-unless
-     * @return $this
      */
     public function requiredUnless(
         string|bool|Closure $condition = null,
         string ...$fieldsAndValues
-    ): self {
+    ): static {
         if ($condition instanceof Closure) {
             $condition = !! $condition();
         }
@@ -926,99 +845,88 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-with
-     * @return $this
      */
-    public function requiredWith(string ...$fields): self
+    public function requiredWith(string ...$fields): static
     {
         return $this->rule('required_with'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-with-all
-     * @return $this
      */
-    public function requiredWithAll(string ...$fields): self
+    public function requiredWithAll(string ...$fields): static
     {
         return $this->rule('required_with_all'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-without
-     * @return $this
      */
-    public function requiredWithout(string ...$fields): self
+    public function requiredWithout(string ...$fields): static
     {
         return $this->rule('required_without'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-without-all
-     * @return $this
      */
-    public function requiredWithoutAll(string ...$fields): self
+    public function requiredWithoutAll(string ...$fields): static
     {
         return $this->rule('required_without_all'.self::arguments($fields));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-required-array-keys
-     * @return $this
      */
-    public function requiredArrayKeys(string ...$keys): self
+    public function requiredArrayKeys(string ...$keys): static
     {
         return $this->rule('required_array_keys'.self::arguments($keys));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-same
-     * @return $this
      */
-    public function same(string $field): self
+    public function same(string $field): static
     {
         return $this->rule('same:'.$field);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-size
-     * @return $this
      */
-    public function size(string|int $value): self
+    public function size(string|int $value): static
     {
         return $this->rule('size:'.$value);
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-sometimes
-     * @return $this
      */
-    public function sometimes(): self
+    public function sometimes(): static
     {
         return $this->rule('sometimes');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-starts-with
-     * @return $this
      */
-    public function startsWith(string ...$values): self
+    public function startsWith(string ...$values): static
     {
         return $this->rule('starts_with'.self::arguments($values));
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-string
-     * @return $this
      */
-    public function string(): self
+    public function string(): static
     {
         return $this->rule('string');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-timezone
-     * @return $this
      */
-    public function timezone(?string $group = null, ?string $country = null): self
+    public function timezone(?string $group = null, ?string $country = null): static
     {
         $arguments = [];
 
@@ -1035,9 +943,8 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-unique
-     * @return $this
      */
-    public function unique(string|Unique $table, string $column = null, mixed $ignore = null): self
+    public function unique(string|Unique $table, string $column = null, mixed $ignore = null): static
     {
         if (is_string($table)) {
             $table = (new Unique($table, $column ?? 'NULL'))->ignore($ignore);
@@ -1048,36 +955,32 @@ trait CoreRules
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-uppercase
-     * @return $this
      */
-    public function uppercase(): self
+    public function uppercase(): static
     {
         return $this->rule('uppercase');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-url
-     * @return $this
      */
-    public function url(): self
+    public function url(): static
     {
         return $this->rule('url');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-ulid
-     * @return $this
      */
-    public function ulid(): self
+    public function ulid(): static
     {
         return $this->rule('ulid');
     }
 
     /**
      * @link https://laravel.com/docs/master/validation#rule-uuid
-     * @return $this
      */
-    public function uuid(): self
+    public function uuid(): static
     {
         return $this->rule('uuid');
     }

--- a/src/Rule.php
+++ b/src/Rule.php
@@ -29,9 +29,8 @@ class Rule implements Iterator, Arrayable
      * Add a rule
      *
      * @param string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array<string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule>|null $rule
-     * @return $this
      */
-    public function rule(string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array|null $rule): self
+    public function rule(string|InvokableRuleContract|RuleContract|ValidationRuleContract|Rule|array|null $rule): static
     {
         if ($rule === null) {
             return $this;
@@ -101,10 +100,8 @@ class Rule implements Iterator, Arrayable
 
     /**
      * Merge the given Rule's underlying rules with this Rule.
-     *
-     * @return $this
      */
-    public function merge(?Rule $rule): self
+    public function merge(?Rule $rule): static
     {
         if ($rule !== null) {
             $this->rules = array_merge($this->rules, $rule->toArray());

--- a/tests/Fixtures/Binding/CustomRuleClass.php
+++ b/tests/Fixtures/Binding/CustomRuleClass.php
@@ -8,7 +8,7 @@ use BradieTilley\Rules\Rule;
 
 class CustomRuleClass extends Rule
 {
-    public function someCustomRule(): self
+    public function someCustomRule(): static
     {
         return $this->push('some_custom_rule');
     }


### PR DESCRIPTION
Hey man, nice library :)

PHP 8 introduced the `static` return type, which represents an object of the same instance. It's a better return type to indicate a "fluent" flow.

See https://php.watch/versions/8.0/static-return-type